### PR TITLE
Added git dependency to apt install step

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
     - 'python-pip'
     - 'python-dev'
     - 'libssl-dev'
+    - 'git'
 
 - name: 'Install pyopenssl'
   pip:


### PR DESCRIPTION
The git step requires that git is installed, ansible won't do this for you